### PR TITLE
fix same pid from pidFile when execute "server start"

### DIFF
--- a/libs/Swoole/Network/Server.php
+++ b/libs/Swoole/Network/Server.php
@@ -180,7 +180,8 @@ class Server extends Base implements Driver
             //已存在ServerPID，并且进程存在
             if (!empty($server_pid) and \Swoole::$php->os->kill($server_pid, 0))
             {
-                exit("Server is already running.\n");
+                if($server_pid != posix_getpid())
+                    exit("Server is already running.\n");
             }
         }
         else


### PR DESCRIPTION
遇到问题是因为我在docker 里面运行 swoole http server。
在docker里面 master主进程 php server.php start 的pid 永远是 1。 
所以当服务异常退出后，docker自动重启时，重启的master主进程pid还是1， 恰好能相应 kill 0这个命令，所以会提示 Server is already running 并退出。
加一个判断 pid是否恰好是自己的pid，可以解决这个问题。