### PR TITLE
php7.0.6 ChangeLog

### DIFF
--- a/libs/factory/db.php
+++ b/libs/factory/db.php
@@ -1,16 +1,18 @@
 <?php
 global $php;
-if (empty($php->config['db'][$php->factory_key]))
+$config = $php->config['db'][$php->factory_key];
+if (empty($config))
 {
     throw new Swoole\Exception\Factory("db->{$php->factory_key} is not found.");
 }
-if (!empty($php->config['db'][$php->factory_key]['use_proxy']))
+$config_use_proxy = $php->config['db'][$php->factory_key]['use_proxy'];
+if (!empty($config_use_proxy))
 {
-    $db = new Swoole\Database\Proxy($php->config['db'][$php->factory_key]);
+    $db = new Swoole\Database\Proxy($config_use_proxy);
 }
 else
 {
-    $db = new Swoole\Database($php->config['db'][$php->factory_key]);
+    $db = new Swoole\Database($config);
     $db->connect();
 }
 return $db;


### PR DESCRIPTION
php7.0.6 ChangeLog
https://bugs.php.net/bug.php?id=69659
Calling isset() or empty() on a dimension of an object that implements ArrayAccess results in the offsetExists method being called.
Instead, when isset() or empty() is called on a subdimension of an object implementing ArrayAccess, the offsetExists method should first be called to check if the dimension exists. If the dimension does not exist, then offsetGet should not be called