### PR TITLE
support bind params for PDO query

### DIFF
--- a/libs/Swoole/SelectDB.php
+++ b/libs/Swoole/SelectDB.php
@@ -613,6 +613,14 @@ class SelectDB
     }
 
     /**
+     * @param $param
+     */
+    function bind($param)
+    {
+        $this->db->_db->bind_params = $param;
+    }
+
+    /**
      * @param $method
      * @param $param
      * @return bool
@@ -629,7 +637,13 @@ class SelectDB
         {
             if (is_array($param))
             {
-                call_user_func_array(array($this, $method), $param);
+                if ($method == 'bind')
+                {
+                    $this->$method($param);
+                } else {
+                    call_user_func_array(array($this, $method), $param);
+                }
+
             }
             else
             {


### PR DESCRIPTION
支持在where查询条件中使用占位符，通过bind参数传递占位符的绑定参数，在PDO的query中支持直接query和存在绑定参数时先prepare再execute这两种处理方式。