### PR TITLE
fix unset $this in php7.1 throw Fatal error

### DIFF
--- a/libs/Swoole/Database/PdoDB.php
+++ b/libs/Swoole/Database/PdoDB.php
@@ -175,7 +175,8 @@ class PdoDB extends \PDO implements Swoole\IDatabase
 	 */
 	function close()
 	{
-		unset($this);
+		//unset($this);
+		return;
 	}
 
     function quote($str)


### PR DESCRIPTION
seems no need to unset $this, auto call __destruct().